### PR TITLE
Add some more stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 *.stl
 *.tar
 *~
+.*.sw?
 .#*
 .DS_Store
+.sw?
 tmp

--- a/clamps/Makefile
+++ b/clamps/Makefile
@@ -1,8 +1,13 @@
 
-SOURCES = hold-down-clamp.scad
+SOURCES = \
+	  hold-down-clamp.scad \
+	  pcb-hold-down.scad \
+	  pcb-work-bracket.scad
 
 include ../common/stl.mk
 
 hold-down-clamp.openscad.stl :
+pcb-hold-down.openscad.stl :
+pcb-work-bracket.openscad.stl : ../common/threads.scad
 
 # The end.

--- a/clamps/Makefile
+++ b/clamps/Makefile
@@ -1,0 +1,8 @@
+
+SOURCES = hold-down-clamp.scad
+
+include ../common/stl.mk
+
+hold-down-clamp.openscad.stl :
+
+# The end.

--- a/clamps/hold-down-clamp.scad
+++ b/clamps/hold-down-clamp.scad
@@ -1,0 +1,51 @@
+//
+// flat-clamp.scad, "by" pjones
+//
+// This is basically a clone of the hold-down clamps that come with an
+// X-Carve.  It's not exact, but it's close enough.  You'll need something
+// like a EZ-lock thread insert for the pivot, and a wingnut or bolt and
+// washer that fit with your wasteboard or t-slots for the anchor.
+//
+// The default pivot size here is for one I got off the internet; it doesn't
+// match the original.
+//
+
+module flat_clamp(pivot_d=[9.6, 7, 6], anchor_w=5.5, h=9.5, l=110, $fn=200)
+{
+    w = 40;
+    pivot_pos = [l - pivot_d[2] * 1.75, w/2, -0.02];
+    slot_sz = [l - anchor_w * 9 - anchor_w, anchor_w, h+0.04];
+    slot_pos = [l - anchor_w * 5 - slot_sz[0], w/2-slot_sz[1]/2, -0.02];
+    slot_min_pos = [slot_pos[0],
+                    slot_pos[1] + slot_sz[1]/2,
+                    slot_pos[2]];
+    slot_max_pos = [slot_pos[0] + slot_sz[0],
+                    slot_pos[1] + slot_sz[1]/2,
+                    slot_pos[2]];
+
+    difference()
+    {
+        cube([l, w, h]);
+        translate(pivot_pos) {
+            cylinder(h=h+0.04, r1=pivot_d[2]/2, r2=pivot_d[1]/2);
+            translate([0, 0, h-0.5])
+            cylinder(h=0.5+0.05, d=pivot_d[0]);
+        }
+        translate(slot_pos) cube(slot_sz);
+        translate(slot_min_pos) cylinder(h=h+0.04, d=slot_sz[1]);
+        translate(slot_max_pos) cylinder(h=h+0.04, d=slot_sz[1]);
+        rotate([0, -30, 0]) translate([-1, -1, -1]) cube([l, w+2, h*3]);
+
+        for (i = [-1:2:1])
+        {
+            translate([-l/4, w*3/16 + i*w*7/8, -0.02])
+            linear_extrude(height=h+0.04)
+                minkowski() {
+                    square([l, w*5/8]);
+                    circle(d=w*3/8);
+                }
+        }
+    }
+}
+
+flat_clamp();

--- a/clamps/pcb-hold-down.scad
+++ b/clamps/pcb-hold-down.scad
@@ -1,0 +1,39 @@
+
+hold_down_height = 1.6;
+hold_down_diameter = 13;
+hold_down_reach = 18;
+hold_down_screw_diameter = 4.95;
+
+//
+// This is a vaguely teardrop shaped hold-down clamp to hold a pcb workpiece
+// flat in the cavity of pcb_work_bracket
+//
+// h=height of the clamp
+// d=outside diameter of the screwed-down part
+// r=reach of the pointy bit
+// sd=screw diameter
+//
+// contributed by @vathpela
+//
+module pcb_hold_down(h=hold_down_height,
+                     d=hold_down_diameter,
+                     r=hold_down_reach,
+                     sd=hold_down_screw_diameter,
+                     $fn=200)
+{
+    difference()
+    {
+        union()
+        {
+            cylinder(h=h, d=d);
+            linear_extrude(height=h)
+                polygon([[0, d/2],
+                         [0, -d/2],
+                         [r, 0]]);
+        }
+        translate([0, 0, -0.01])
+            cylinder(h=h+0.02, d=sd);
+    }
+}
+
+pcb_hold_down();

--- a/clamps/pcb-work-bracket.scad
+++ b/clamps/pcb-work-bracket.scad
@@ -1,0 +1,93 @@
+use <../common/geometry.scad>
+use <../common/threads.scad>
+
+pcb_w = 51.25;
+pcb_d = 76.25;
+pcb_h = 1.60;
+hold_down_pitch = 75.00;
+
+//
+// this is a bracket to attach a small pcb workpiece to the wasteboard of my
+// CNC, laser etcher, or PnP machines.
+//
+// dimensions for the pcb are provided by pcb=[x,y,z]
+// hold_down_pitch is the spacing on which you can clamp to the mill's
+// wasteboard
+//
+// contributed by @vathpela
+//
+module pcb_work_bracket(pcb=[pcb_w, pcb_d, pcb_h], hdp=hold_down_pitch,
+                        debug=false, $fn=200)
+{
+    pcbw = pcb[0];
+    pcbl = pcb[1];
+    pcbh = pcb[2];
+
+    anchor_d = [9.62, 7, 6];
+    anchor_h = 10;
+
+    space = ceil(anchor_d[0]) + 2;
+    l = max(pcbl + 4, hdp * (ceil(pcbl/hdp)-1) + space);
+    if (debug)
+        echo(pcbw + space * (pcbl < 3 * space ? 2: 1),
+             hdp * ceil(pcbw/hdp) + space);
+    w = max(pcbw + space * (pcbl < 3 * space ? 4: 2),
+            hdp * ceil(pcbw/hdp) + space);
+    h = anchor_h + 0.48;
+
+    function gcd(a,b) = a <= 0 || b <= 0
+                        ? min(sign(a), sign(b))
+                        : (a % b == 0 ? b : gcd(b,a % b));
+    function lcm(a,b) = a * (b / gcd(a, b));
+
+    module anchor(thread=false)
+    {
+        translate([0, 0, -h-1])
+            cylinder(h=h+2, d=5);
+        translate([0, 0, -anchor_h])
+        {
+            if (thread)
+            {
+                translate([0, 0, anchor_h-0.49])
+                    rotate([180, 0, 0])
+                        metric_thread(diameter=anchor_d[0], pitch=2.5,
+                                      length=anchor_h);
+            } else {
+                cylinder(h=anchor_h, r1=anchor_d[2]/2, r2=anchor_d[1]/2);
+            }
+            translate([0, 0, anchor_h-0.5])
+                cylinder(h=0.5+0.05, d=anchor_d[0]);
+        }
+
+    }
+
+    difference()
+    {
+        cube([l, w, h]);
+        translate([(l-pcbl)/2, (w-pcbw)/2, h-pcb_h])
+            cube([pcbl, pcbw, pcbh + 0.02]);
+
+        xholes = floor(l / hdp) + 1;
+        yholes = floor(w / hdp) + 1;
+        if (debug)
+            echo("xholes", xholes, "yholes", yholes);
+        for (i = [0:1:2])
+        {
+            for (j = [0:1:1])
+            {
+                pos = [i * hdp + space/2,
+                       j * w - (j-1) * space/2 - j * space/2,
+                       h];
+                if (debug)
+                    echo(pos);
+                translate(pos)
+                    anchor(true);
+            }
+        }
+
+        translate([l/2, w/2, -5])
+            cylinder(d=7, h=20);
+    }
+}
+
+pcb_work_bracket();

--- a/common/.gitignore
+++ b/common/.gitignore
@@ -1,0 +1,1 @@
+threads.scad

--- a/common/copies.scad
+++ b/common/copies.scad
@@ -2,7 +2,7 @@
   author: Christopher O'Brien  <obriencj@gmail.com>
   license: GPL v3
 */
-
+use <../common/math.scad>
 
 module copy_mirror(plane=[0, 0, 1]) {
      children();
@@ -56,5 +56,106 @@ module duplicate(move_v=[0,0,0], rotate_v=[0,0,0]) {
      };
 }
 
+
+//
+// isomers() builds stereoisometric copies, horrifyingly laid out on the xy
+// plane.
+//
+// you can specify how many copies with n=<NUMBER> or ns[xN, yN, zN],
+// n=1 is the same as ns=[1, 0, 0]
+// If the single n is nonzero, it is used, else the vector is.
+//
+// This is astonishingly close to actual n-dimensional chess.  You probably
+// only want to choose n>1 on 2 or fewer planes at the same time. Inputs:
+//
+// contributed by @vathpela
+//
+module isomers(n=0, ns=[1, 0, 0], size=[1, 1, 1], debug=false)
+{
+    nm = [n ? n : ns[0], n ? 1 : ns[1], n ? 1 : ns[2]];
+
+    xn = max(nm[0], 1);
+    yn = max(nm[1], 1);
+    zn = max(nm[2], 1);
+    if (debug)
+        echo("[xn,yn,zn]", [xn,yn,zn]);
+    m = logn(xn*yn*zn, 2);
+
+    xs = size[0];
+    ys = size[1];
+    zs = size[2];
+    if (debug)
+        echo("[xs,ys,zs]", [xs,ys,zs]);
+
+    module zmirrorshift(origin=[0, 0, 0], x, y)
+    {
+        if (debug)
+            echo("zmirror origin", origin);
+        for (z = [0:1:zn-1])
+        {
+            shift0 = [origin[0] + xs/2 * 1.2 * (z-0.5)*-zn,
+                      origin[1],
+                      origin[2] + zs];
+            shift1 = [origin[0] + xs/2 * 1.2 * (z-3.5)*zn - (xn) * xs * 1.2,
+                      origin[1],
+                      origin[2]];
+            shift2 = [origin[0] + xs/2 * 1.2 * (z-0.5)*-zn,
+                      origin[1],
+                      origin[2]];
+
+            if (z % 2 == 0 && zn != 1) {
+                if (debug)
+                    echo("za [z]", [z], "[zs]", [zs], "t([x,y,z])", shift0);
+                translate(shift0) mirror([0, 0, 1]) children();
+            } else {
+                if (debug)
+                    echo("zb [z]", [z], "[zs]", [zs], "t([x,y,z])", shift1);
+                translate(zn == 1 ? shift2 : shift1) children();
+            }
+        }
+    }
+
+    module ymirrorshift(origin=[0, 0, 0], x)
+    {
+        if (debug)
+            echo("ymirror origin", origin);
+        for (y = [0:1:yn-1])
+        {
+            shift=[origin[0],
+                   origin[1] + y * ys * 1.2,
+                   origin[2]];
+            if (debug)
+                echo("ya [x,y,z]", [x,y,0], "[ys,zs]", [ys,zs], "t([x,y,z])", shift);
+            if (y % 2 == 0) {
+                zmirrorshift(shift, x, y) mirror([0, 1, 0]) children();
+            } else {
+                zmirrorshift(shift, x, y) children();
+            }
+        }
+    }
+
+    module xmirrorshift(origin=[0, 0, 0])
+    {
+        if (debug)
+            echo("xmirror origin", origin);
+        for (x = [0:1:xn-1])
+        {
+            shift=[origin[0] + x * xs * 1.2,
+                   origin[1],
+                   origin[2]];
+            if (debug)
+                echo("xa [x,y,z]", [x,0,0],
+                     "[xs,ys,zs]", [xs,ys,zs],
+                     "t([x,y,z])", shift);
+            if (x % 2 == 0) {
+                ymirrorshift(shift, x) mirror([1, 0, 0]) children();
+            } else {
+                ymirrorshift(shift, x) children();
+            }
+        }
+    }
+
+    xmirrorshift() children();
+}
 
 // The end.

--- a/common/defaults.mk
+++ b/common/defaults.mk
@@ -1,6 +1,7 @@
 
-OPENSCAD ?= openscad
 ADMESH ?= admesh
+OPENSCAD ?= openscad
 TIME ?= time --verbose
+WGET ?= wget
 
 # vim:ft=make

--- a/common/deps.mk
+++ b/common/deps.mk
@@ -1,2 +1,5 @@
 
 ../common/utils.scad : | ../common/copies.scad
+
+../common/threads.scad :
+	$(WGET) -O $(TOPDIR)/common/threads.scad https://dkprojects.net/openscad-threads/threads.scad

--- a/common/geometry.scad
+++ b/common/geometry.scad
@@ -1,9 +1,39 @@
-
+//
+// find the distance from the center of a chord with length c to the center of the circle
+// it intersects
+//
 // c = length of a chord through a circle
 // h = height from center of chord to the tangential point on the circle
-// segment_depth == distance from the center of the chord to the center of the
-//                  circle
+//     the tangential point on the circle
+//
 // see https://en.wikipedia.org/wiki/Circular_segment for math
+//
+// contributed by @vathpela
+//
 function segment_depth(h, c) = (h/2) + (pow(c,2)/(8*h)) - h;
+
+//
+// radius of a circle given a chord through it
+//
+// c = length of a chord through a circle
+// h = height from center of chord to the tangential point on the circle the
+//     tangential point on the circle
+//
+// contributed by @vathpela
+//
 function circle_r_from_chord(h, c) = h + segment_depth(h, c);
 
+//
+// the distance formula for 2d space
+//
+// contributed by @vathpela
+//
+function distance(xy0, xy1) = sqrt(pow((xy1[0] - xy0[0]), 2)
+                                   + pow((xy1[1] - xy1[1]), 2));
+
+//
+// the mean of two points in 2d space
+//
+// contributed by @vathpela
+//
+function center(xy0, xy1) = [(xy1[0]+xy0[0])/2, (xy1[1]+xy0[1])/2];

--- a/common/math.scad
+++ b/common/math.scad
@@ -1,0 +1,25 @@
+//
+// just some useful general math utilities
+//
+
+//
+// min() and max() give you the lower or higher of their arguments,
+// respectively.  They behave asymmetrically at 0, so as to establish a
+// stable sort order, merely reversed, no matter which order the inputs come
+// in.
+//
+// contributed by @vathpela
+//
+function min(x, y) = y > x ? x : y;
+function max(x, y) = x >= y ? x : y;
+
+//
+// logx(x, b) is log base x of b aka logX(b)
+//
+// *sigh*, openscad's math primitives are so defective
+//
+// contributed by @vathpela
+//
+function logx(x, b) = log(x) / log(b);
+
+

--- a/common/utils.scad
+++ b/common/utils.scad
@@ -70,4 +70,36 @@ module words(txt_v, size=6, thick=5, spacing=0,
 }
 
 
+//
+// rotate the results of linear_extrude() so instead of extruding towards
+// positive z, it's extruding towards positive y, with the object in the
+// positive xz space.
+//
+// contributed by @vathpela
+//
+module xy_to_xyz()
+{
+    rotate([90, 0, 0])
+        mirror([0, 0, 1])
+            children();
+}
+
+//
+// extrude a 2d polygon as if it's in the positive xz space, extruding into
+// positive y.
+//
+// contributed by @vathpela
+//
+module linear_extrude_y(height=1, center=false, convexity=10, twist=0,
+                        slices=20, scale=1.0, $fn=16)
+{
+    xy_to_xyz()
+        linear_extrude(height=height, center=center,
+                       convexity=convexity, twist=twist,
+                       slices=slices, scale=scale, $fn=$fn)
+            children();
+}
+
+
+
 // The end.

--- a/kitchen/Makefile
+++ b/kitchen/Makefile
@@ -1,0 +1,9 @@
+
+SOURCES = \
+	  vacuum-pump-gasket.scad
+
+include ../common/stl.mk
+
+vacuum-pump-gasket.openscad.stl :
+
+# The end.

--- a/kitchen/vacuum-pump-gasket.scad
+++ b/kitchen/vacuum-pump-gasket.scad
@@ -1,0 +1,53 @@
+//
+// vacuum_pump_gasket is a gasket to make a Vacu Vin Wine Saver Pump[0],
+// which is entirely hard injection molded plastic and expects a rubber
+// stopper value to be on top of a wine bottle, interface better with with
+// Ziploc Vacuum Pump bags[1], which have hard acrylic sheet valves
+// expecting to be used with a motorized pump with rubber gaskets.  The
+// motorized pump is completely overkill for removing ~10cc of air from a
+// plastic bag, the hand pump works very well and doesn't take up valuable
+// real-estate on the kitchen counter.
+//
+// to be printed with something like FilaFlex40 or NinjaFlex 85A, or
+// something even softer if you have it.
+//
+// [0] https://www.amazon.com/Original-Vacu-Vin-Vacuum-Stoppers/dp/B000GA3KCE
+// [1] https://www.amazon.com/Ziploc-Vacuum-Pump-Refill-Quart/dp/B0145O2AC2/
+//
+// contributed by @vathpela
+//
+
+
+id = 26.75;
+od0 = 35.5;
+od1h = 2.5;
+od1 = 40;
+od2h = 6;
+od2 = 39.5;
+od3h = 7.5;
+od3 = 35.75;
+
+module vacuum_pump_gasket(id=id, od0=od0, od1h=od1h, od1=od1,
+                          od2h=od2h, od2=od2, od3h=od3h, od3=od3,
+                          $fn=200)
+{
+    t = 1;
+
+    points = [[id/2-t, 0],
+              [id/2-t, od1h],
+              [id/2, od1h],
+              [id/2, t],
+              [od0/2, t],
+              [od1/2, od1h],
+              [od2/2, od2h],
+              [od3/2, od3h],
+              [od3/2+t, od3h],
+              [od2/2+t, od2h],
+              [od1/2+t, od1h],
+              [od0/2+t, 0],
+              ];
+    rotate_extrude()
+        polygon(points);
+}
+
+vacuum_pump_gasket();

--- a/makerslide/Makefile
+++ b/makerslide/Makefile
@@ -1,0 +1,11 @@
+
+SOURCES = \
+	  insert.scad \
+	  makerslide.scad
+
+include ../common/stl.mk
+
+insert.openscad.stl :
+makerslide.openscad.stl :
+
+# The end.

--- a/makerslide/insert.scad
+++ b/makerslide/insert.scad
@@ -1,0 +1,20 @@
+insert_height = 2.10;
+insert_width = 9.00;
+screw_diameter=  5.00;
+
+//
+// this is a makerslide t-nut insert that expects to be fitted with a brass
+// thread insert that melts nicely into a 5mm hole (by default)
+//
+module insert(h=insert_height, w=insert_width, d=screw_diameter, $fn=200)
+{
+    l = d * 2.5;
+    difference()
+    {
+        cube([w, l, h]);
+        translate([w/2, l/2, -0.1])
+        cylinder(d=d-0.1, h=h+0.2);
+    }
+}
+
+insert();

--- a/makerslide/makerslide.scad
+++ b/makerslide/makerslide.scad
@@ -1,0 +1,188 @@
+//
+// a model for makerslide, i.e. aluminum rail extrusion.  This is useful for
+// making e.g. riser stands and similar for devices constructed from
+// extruded aluminum rail.
+//
+// contributed by @vathpela
+//
+
+//
+// this function provides the width of makerslide (on x or y) for models
+// that need to include it for e.g. translate() coordinates
+//
+function makerslide_width() = 20;
+
+//
+// make some makerslide or holes to house makerslide
+//
+// a length of makerslide, originating at (0,0,0)-(20,0,20)
+//
+// cutout:     false=makerslide, true=a hole to put makerslide in
+// length:     how far to extrude in +y space
+// railmask:   [bottom, right, top, left] list of boolean values for which
+//             rails to carve out from the extrusion (or extrude fill for in
+//             the cutout case).  the order assumes we're looking from -x on
+//             the left and +x on the right, with +y growing away from the
+//             viewer
+// flangemask: [top right, top left, bottom left, bottom right] list of boolean
+//             values for which corners get a triangular 3.82mm x 3.82mm x 5.4
+//             flange pointing up or down for stacking (4x4x5.66 in cutout
+//             mode)
+//
+module makerslide(length=25, cutout=false,
+                  railmask=[true,true,true,true],
+                  flangemask=[false, false, false, false],
+                  $fn=100)
+{
+    w = makerslide_width();
+    h = makerslide_width();
+    offset0 = cutout ? 0.2 : 0.2;
+    offset1 = cutout ? -0.4 : -0.2;
+    offset2 = cutout ? 0.6 : 0;
+    offset3 = cutout ? 0.2 : 0;
+
+    // just extrude a right triangle...
+    module rt(rtw, rth, l)
+    {
+        hyp = sqrt(rtw*rtw+rth*rth);
+
+        translate([0, l/2, 0])
+            rotate([90, 0, 0]) rotate([0, 0, -45])
+                linear_extrude(height=l, center=true)
+                    polygon([[0, 0],
+                             [rtw, 0],
+                             [rtw, rth]]);
+    }
+
+    module flange(quadrant)
+    {
+        fw = cutout ? 4 : 3.82;
+        hyp = sqrt(fw*fw*2);
+
+        rotates=[[180, 0, 0],
+                 [0, 0, 0],
+                 [0, 0, 0],
+                 [180, 0, 0]];
+        shifts=[[w-hyp/2, length-0.01, h+1],
+                [w-hyp/2, -0.01, -1],
+                [-hyp/2, -0.01, -1],
+                [-hyp/2, length-0.01, h+1]];
+
+        translate(shifts[quadrant])
+            rotate(rotates[quadrant]) {
+                rt(fw, fw, length+0.02);
+                translate([0, 0, -0.01])
+                    cube([hyp, length+0.02, 1.02]);
+        }
+    }
+
+    module rail()
+    {
+        translate([0,length+0.01,0])
+            rotate([90,0,0])
+                linear_extrude(height=length+0.02)
+                    offset(delta=offset0, chamfer=cutout)
+                    offset(delta=offset1, chamfer=cutout)
+                    polygon([[8, -0.01 - offset2],
+                             [8, 2],
+                             [4, 2],
+                             [8, 6],
+                             [12, 6],
+                             [16, 2],
+                             [12, 2],
+                             [12, -0.01 - offset2]]);
+    }
+
+    railshifts = [[0,0,0], [w,0,0], [w,0,h], [0,0,h]];
+
+    difference()
+    {
+        union()
+        {
+            translate([0,0,h]) rotate([-90,0,0])
+            {
+                linear_extrude(height=length)
+                    offset(delta=offset3, chamfer=false)
+                        square([w, h]);
+            }
+            for (i = [0:1:3])
+            {
+                if (flangemask[i] && cutout)
+                    flange(i);
+            }
+        }
+        for (i = [0:1:3]) {
+            if (railmask[i])
+                translate(railshifts[i])
+                    rotate([0,-90 * i,0])
+                        rail();
+            if (!flangemask[i] && !cutout)
+                flange(i);
+        }
+        if (!cutout)
+            translate([w/2, -0.01, h/2])
+                rotate([-90,0,0])
+                    cylinder(d=3.95, h=length+0.02);
+    }
+}
+
+//
+// this is a t-slot insert.  I wouldn't recommend using it for anything that
+// needs a bunch of torque.
+//
+module makerslide_insert($fn=100)
+{
+    translate([10,6,0])
+        rotate([90,0,0])
+            difference()
+            {
+                union()
+                {
+                    linear_extrude(height=12)
+                        polygon([[6,2.2], [6,5], [14,5], [14, 2.2]]);
+                    translate([10,5,6])
+                        rotate([90,0,0])
+                            cylinder(d=3.6, h=4);
+                }
+                translate([10,5.01,6])
+                    rotate([90,0,0])
+                        cylinder(d=2.95, h=5.02);
+                translate([0,0,-0.01])
+                    linear_extrude(height=12.02)
+                        offset(delta=0.4, chamfer=true)
+                        offset(delta=-0.2, chamfer=true)
+                        {
+                            polygon([
+                                     [0,10],
+                                     [4,2],
+                                     [8,6],
+                                     ]);
+                            polygon([
+                                     [12,6],
+                                     [16,2],
+                                     [20,10],
+                                     ]);
+                        }
+            }
+}
+
+//////
+//
+// and some demos
+//
+//////
+
+// make some makerslide at the default length
+makerslide();
+// make a box with a cutout to feed it through
+difference() {
+    translate([-5,10,-5])
+        cube([30, 24.98, 30]);
+    translate([0,9.99,0])
+        makerslide(cutout=true, railmask=[true,false,true,false]);
+    // add a M3 screw hole
+    translate([19.99,20,10]) rotate([0,90,0]) cylinder(d=2.95, h=5.1, $fn=100);
+}
+// add some inserts
+translate([-10,0,0]) makerslide_insert();
+translate([20,20,-10]) rotate([0,-90,0]) makerslide_insert();

--- a/mehcorn/Makefile
+++ b/mehcorn/Makefile
@@ -3,6 +3,6 @@ SOURCES = mehcorn.scad paintstand.scad
 
 include ../common/stl.mk
 
-mehcorn.openscad.stl : threads.scad
+mehcorn.openscad.stl : ../common/threads.scad
 
 # The end.

--- a/mehcorn/mehcorn.scad
+++ b/mehcorn/mehcorn.scad
@@ -7,9 +7,7 @@
 
 
 
-// GPL v3 Threading module for OpenSCAD
-// http://dkprojects.net/openscad-threads/
-use <threads.scad>;
+use <../common/threads.scad>
 
 
 module freecorn_threads(radius, internal=0) {

--- a/stands/Makefile
+++ b/stands/Makefile
@@ -1,0 +1,13 @@
+
+SOURCES = \
+	  xcarve-stand-left.scad \
+	  xcarve-stand-pad.scad \
+	  xcarve-stand-right.scad
+
+include ../common/stl.mk
+
+xcarve-stand-left.openscad.stl : xcarve-stand.scad
+xcarve-stand-pad.openscad.stl : xcarve-stand.scad
+xcarve-stand-right.openscad.stl : xcarve-stand.scad
+
+# The end.

--- a/stands/xcarve-stand-left.scad
+++ b/stands/xcarve-stand-left.scad
@@ -1,0 +1,12 @@
+use <xcarve-stand.scad>
+
+difference()
+{
+    xcarve_stand();
+
+//    l = makerslide_width()*3/2;
+//    translate([-1, l/2+0.2, -25])
+//        cube([35, l/2, 200]);
+//    translate([-1, -1, -25])
+//        cube([35, l/2+1, 200]);
+}

--- a/stands/xcarve-stand-pad.scad
+++ b/stands/xcarve-stand-pad.scad
@@ -1,0 +1,3 @@
+use <xcarve-stand.scad>
+
+xcarve_stand_pad();

--- a/stands/xcarve-stand-right.scad
+++ b/stands/xcarve-stand-right.scad
@@ -1,0 +1,12 @@
+use <xcarve-stand.scad>
+
+difference()
+{
+    mirror([0, 1, 0]) xcarve_stand();
+
+//    l = makerslide_width()*3/2;
+//    translate([-1, l/2+0.2, -25])
+//        cube([35, l/2, 200]);
+//    translate([-1, -1, -25])
+//        cube([35, l/2+1, 200]);
+}

--- a/stands/xcarve-stand.scad
+++ b/stands/xcarve-stand.scad
@@ -1,0 +1,103 @@
+
+use <../makerslide/makerslide.scad>
+use <../common/copies.scad>
+
+function xcarve_stand_width() = makerslide_width() * 1.5;
+function xcarve_stand_length() = makerslide_width() * 3 / 2;
+
+module xcarve_stand($fn=200)
+{
+    M3 = 2.95;
+    M5 = 4.95;
+
+    scale = 1.5;
+    w = xcarve_stand_width() / scale;
+    h = 130-w;
+    l = xcarve_stand_length();
+    // width of the annoying flange on the original x-carve gantry beams
+    // (plus 0.2mm of slop)
+    fw = 4;
+    topw = 22;
+
+    shift = scale/4;
+
+    rotate([90, 0, 0])
+    translate([-(w*scale)/2, 0, -(h+l)/2])
+    difference()
+    {
+        cube([w*scale, l, w + h+w*0.2]);
+        union()
+        {
+            translate([0, -0.02, h])
+                makerslide(length=topw+0.04, cutout=true,
+                           railmask=[true, false, false, false]);
+            translate([0, topw-0.02, h])
+                makerslide(length=l-topw+0.06, cutout=true,
+                           railmask=[true, false, false, false]);
+        }
+        translate([-0.02, topw, h+makerslide_width()])
+            cube([w*scale+0.04, l, 11]);
+        // add some M5 screw holes
+        translate([w/2, l-w/2, w/2+h])
+            rotate([0,90,0]) cylinder(d=M5, h=w+1, $fn=100);
+        translate([w/2, w/2, w/2+h])
+            rotate([0,90,0]) cylinder(d=M5, h=w+1, $fn=100);
+
+        translate([w*shift*4/5, -0.1, w*shift*3/4])
+        {
+            makerslide(length=l+0.2, cutout=true,
+                       railmask=[true, false, false, false],
+                       flangemask=[false, false, true, false]);
+            translate([w/2, l-w/2, w/2])
+                rotate([0,90,0]) cylinder(d=M5, h=w, $fn=100);
+            translate([w/2, w/2, w/2])
+                rotate([0,90,0]) cylinder(d=M5, h=w, $fn=100);
+
+            translate([0, 0, w-0.01])
+                makerslide(length=l+0.2, cutout=true,
+                           railmask=[false, false, true, false],
+                           flangemask=[false, false, false, true]);
+            translate([-w/2, l-w/2, w*3/2])
+                rotate([0,90,0]) cylinder(d=M5, h=w+1, $fn=100);
+            translate([-w/2, w/2, w*3/2])
+                rotate([0,90,0]) cylinder(d=M5, h=w+1, $fn=100);
+            translate([w/2, l-w/2, w*3/2])
+                rotate([0,90,0]) cylinder(d=M5, h=w+1, $fn=100);
+            translate([w/2, w/2, w*3/2])
+                rotate([0,90,0]) cylinder(d=M5, h=w+1, $fn=100);
+        }
+    }
+}
+
+module xcarve_stand_pad($fn=200)
+{
+    difference()
+    {
+        cube([xcarve_stand_width() + 4, xcarve_stand_length() + 4, 4]);
+        translate([2, 2, 2])
+            cube([xcarve_stand_width(), xcarve_stand_length(), 4]);
+    }
+}
+
+module demo()
+{
+    l = makerslide_width()*3/2;
+//    for (i=[-3:2:0])
+//    {
+//        copy_mirror([1, 0, 0])
+//            translate([i*l, 0, 0])
+//                xcarve_stand();
+//    }
+    isomers(ns=[2, 2, 1], size=[l, 115, l]) xcarve_stand();
+}
+
+module pad_demo()
+{
+    for (i=[0:1:3]) {
+        translate([-xcarve_stand_width()*2, (xcarve_stand_length()+6)*i, 0])
+            xcarve_stand_pad();
+    }
+}
+
+demo();
+pad_demo();

--- a/tape/Makefile
+++ b/tape/Makefile
@@ -1,0 +1,8 @@
+
+SOURCES = tape.scad
+
+include ../common/stl.mk
+
+tape.openscad.stl :
+
+# The end.

--- a/tape/tape.scad
+++ b/tape/tape.scad
@@ -1,0 +1,23 @@
+tape_length = 25.4 * 3;
+tape_width = 19.05;
+tape_thickness = 0.2;
+
+//
+// This builds flat tape.
+//
+// This is useful for reassembling thin-walled objects that are too big to
+// print, and thus have been cut in half to print.  Basically put the tape
+// in place and hit it with a heat gun, or if you used ABS, brush it with
+// acetate.
+//
+// by default it's 3" x 0.75" x 0.2mm, with the expectation of being printed
+// at 0.2mm layer height (i.e. only the first layer)
+//
+// contributed by @vathpela
+//
+module tape(length=tape_length, width=tape_width, height=tape_thickness)
+{
+    cube([width, length, height]);
+}
+
+tape();


### PR DESCRIPTION
As the subject suggests, this is a PR that adds some more stuff, including:

- some more geometry and math helpers
- helpers for shapes that are rounded as if milled, rather than turned
- a copier that can generate stereoisomers of somewhat arbitrary orientation
- some hold-down clamps
- a pcb workpiece bracket
- a parametric model for extruded aluminum slide rail, both positive and negative, and inserts.

The one thing here that might be something you really don't want is https://github.com/vathpela/openscad-mundane/commit/789b248775d105d6da020bbd9dd3a690ec1a423a ; if you don't want to carry that in the tree, let me know and I'll send you an alternate version of this PR.